### PR TITLE
Prevent double copy of backup data.

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -16,7 +16,7 @@ func BackupData(cfg *Config, upgradeInfo *UpgradeInfo) error {
 	// Stamp file for completion tracking.
 	backupStamp := fmt.Sprintf("%s/.keep", backupDir)
 	// If stamp exists, this plan has executed the backup already.
-	if _, err := os.Stat(backupStamp); os.IsExist(err) {
+	if _, err := os.Stat(backupStamp); err == nil {
 		return nil
 	}
 	// Make backup dir if it doesn't exist.

--- a/backup_test.go
+++ b/backup_test.go
@@ -62,14 +62,14 @@ func (s *upgradeTestSuite) TestNoDoubleBackupDataDir() {
 	keep := fmt.Sprintf("%s/%s", backupDir, ".keep")
 	s.Require().FileExists(keep)
 	// Remove backup but leave keep file.
-	err = os.RemoveAll(backupDir+"/data")
+	err = os.RemoveAll(backupDir + "/data")
 	s.Require().NoError(err)
 	s.Require().FileExists(keep)
 	// Verify data not copied again.
 	err = cosmovisor.DoUpgrade(cfg, info)
 	s.Require().NoError(err)
 	// Backup dir should not exist.
-	s.Require().NoDirExists(backupDir+"/data")
+	s.Require().NoDirExists(backupDir + "/data")
 }
 
 func (s *upgradeTestSuite) TestNoBackupDataDir() {

--- a/backup_test.go
+++ b/backup_test.go
@@ -36,6 +36,42 @@ func (s *upgradeTestSuite) TestBackupDataDir() {
 	s.Require().FileExists(keep)
 }
 
+func (s *upgradeTestSuite) TestNoDoubleBackupDataDir() {
+	home := copyTestData(s.T(), "validate")
+	data := fmt.Sprintf("%s/%s", home, "data")
+	cfg := &cosmovisor.Config{Home: home, Name: "dummyd", DataDir: data}
+	info := &cosmovisor.UpgradeInfo{Name: "chain2"}
+
+	err := cosmovisor.DoUpgrade(cfg, info)
+	s.Require().NoError(err)
+	// Backup dir should now exist.
+	backupDir := cfg.BackupDir(info.Name)
+	s.Require().DirExists(backupDir)
+	// Verify copied files exist.
+	appDbName := fmt.Sprintf("%s/%s", backupDir, "data/application.db")
+	s.Require().FileExists(appDbName)
+	appBz, err := ioutil.ReadFile(appDbName)
+	s.Require().NoError(err)
+	s.Require().Equal(string(appBz), "test\n")
+	stateDbName := fmt.Sprintf("%s/%s", backupDir, "data/modulesDir/state.db")
+	s.Require().FileExists(stateDbName)
+	stateBz, err := ioutil.ReadFile(stateDbName)
+	s.Require().NoError(err)
+	s.Require().Equal(string(stateBz), "test\n")
+	// Verify keep file exists.
+	keep := fmt.Sprintf("%s/%s", backupDir, ".keep")
+	s.Require().FileExists(keep)
+	// Remove backup but leave keep file.
+	err = os.RemoveAll(backupDir+"/data")
+	s.Require().NoError(err)
+	s.Require().FileExists(keep)
+	// Verify data not copied again.
+	err = cosmovisor.DoUpgrade(cfg, info)
+	s.Require().NoError(err)
+	// Backup dir should not exist.
+	s.Require().NoDirExists(backupDir+"/data")
+}
+
 func (s *upgradeTestSuite) TestNoBackupDataDir() {
 	home := copyTestData(s.T(), "validate")
 	cfg := &cosmovisor.Config{Home: home, Name: "dummyd", DataDir: ""}


### PR DESCRIPTION
* Correctly detect existence of backup keep file so the backup copy process does not run again after failed upgrade.